### PR TITLE
fix(dependency): update mockito version to support java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
     <artifactId>claimant-payment</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -18,7 +17,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.7.22</version>
+            <version>2.22.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The version of mockito does not support Java 11+. Bumped so it supports Java 11.